### PR TITLE
Removing ext-cassandra from the required elements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
     ]
   },
   "require": {
-    "php": ">=5.3",
-    "ext-cassandra": "*"
+    "php": ">=5.3"
   }
 }


### PR DESCRIPTION
We're using this feature here for development purpose only, like having PhpStorm running on Windows, with the stubs declared, and executing the code on Linux, where the actual extension is loaded. Why do you need the extension declared as require?